### PR TITLE
feat: stats nightly refresh (materialized views)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,69 @@ Simply enter the `deploy/docker-compose` folder, copy the given `deploy/docker-c
 
 #### Initial deployment setup
 
+On first deploy, after `docker compose up -d`, run migrations and seed the GeoIP database:
+
+```bash
+docker compose exec app php artisan migrate --force
+docker compose exec app php artisan ip-geolocation:update
+```
+
+## Nethvoice stats
+
+Nightly-refreshed `nethvoice_*` PostgreSQL materialized views expose pre-flattened phone system stats for Metabase/Grafana without live JSONB unpacking. The views are created by a migration and refreshed by `App\Jobs\RefreshNethvoiceStatsMaterializedViews`, scheduled at 02:00 via `App\Console\Kernel`.
+
+To trigger a manual refresh:
+
+```bash
+docker compose exec app php artisan nethvoice:refresh-stats
+```
+
+### Test locally with podman and a production dump
+
+Requires `podman` and `podman-compose`.
+
+**1. Start the database**
+
+```bash
+podman-compose up -d database
+```
+
+**2. Load a production dump**
+
+```bash
+zcat dump.sql.gz | podman exec -i phonehome-development_database_1 psql -U phonehome -d phonehome -q
+```
+
+**3. Build the production image**
+
+```bash
+podman build -f containers/php/Dockerfile --target production -t phonehome-app-prod:test .
+```
+
+**4. Run migrations and refresh stats**
+
+```bash
+podman run --rm --network=host \
+  -e DB_HOST=127.0.0.1 -e DB_PORT=5432 \
+  -e DB_DATABASE=phonehome -e DB_USERNAME=phonehome -e DB_PASSWORD=phonehome \
+  -e APP_KEY=base64:jobMaruKa1iNGS74JK7PGywi5zGWdgIo0HoMG0B+hrY= \
+  -e APP_ENV=production \
+  phonehome-app-prod:test sh -c "php artisan migrate --force && php artisan nethvoice:refresh-stats"
+```
+
+To rollback a migration:
+```bash
+podman run --rm --network=host \
+  -e DB_HOST=127.0.0.1 -e DB_PORT=5432 \
+  -e DB_DATABASE=phonehome -e DB_USERNAME=phonehome -e DB_PASSWORD=phonehome \
+  -e APP_KEY=base64:jobMaruKa1iNGS74JK7PGywi5zGWdgIo0HoMG0B+hrY= \ 
+  -e APP_ENV=production \
+  phonehome-app-prod:test sh -c "php artisan migrate rollback"
+```
+
+**5. Verify views are populated**
+
+```bash
+podman exec -i phonehome-development_database_1 psql -U phonehome -d phonehome -c \
+  "SELECT matviewname, pg_size_pretty(pg_total_relation_size(matviewname::regclass)) FROM pg_matviews WHERE matviewname LIKE 'nethvoice%' ORDER BY matviewname;"
+```

--- a/app/Console/Commands/NethvoiceRefreshStatsCommand.php
+++ b/app/Console/Commands/NethvoiceRefreshStatsCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+//
+// Copyright (C) 2026 Nethesis S.r.l.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+
+namespace App\Console\Commands;
+
+use App\Jobs\RefreshNethvoiceStatsMaterializedViews;
+use Illuminate\Console\Command;
+
+class NethvoiceRefreshStatsCommand extends Command
+{
+    protected $signature = 'nethvoice:refresh-stats';
+
+    protected $description = 'Refresh the nethvoice_* stats materialized views';
+
+    public function handle(): int
+    {
+        $count = count(RefreshNethvoiceStatsMaterializedViews::VIEWS);
+        $this->info(date('Y-m-d\TH:i:s')." Refreshing {$count} nethvoice materialized views...");
+        dispatch_sync(new RefreshNethvoiceStatsMaterializedViews);
+        $this->info(date('Y-m-d\TH:i:s').' Done.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/PhonehomeRefreshDashboardStatsCommand.php
+++ b/app/Console/Commands/PhonehomeRefreshDashboardStatsCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+//
+// Copyright (C) 2026 Nethesis S.r.l.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+
+namespace App\Console\Commands;
+
+use App\Jobs\RefreshPhonehomeDashboardMaterializedViews;
+use Illuminate\Console\Command;
+
+class PhonehomeRefreshDashboardStatsCommand extends Command
+{
+    protected $signature = 'phonehome:refresh-dashboard-stats';
+
+    protected $description = 'Refresh the phonehome_* dashboard materialized views';
+
+    public function handle(): int
+    {
+        $count = count(RefreshPhonehomeDashboardMaterializedViews::VIEWS);
+        $this->info(date('Y-m-d\TH:i:s')." Refreshing {$count} phonehome dashboard materialized views...");
+        dispatch_sync(new RefreshPhonehomeDashboardMaterializedViews);
+        $this->info(date('Y-m-d\TH:i:s').' Done.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Jobs\RefreshNethvoiceStatsMaterializedViews;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -12,7 +13,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        $schedule->command("ip-geolocation:update")->daily();
+        $schedule->command('ip-geolocation:update')->daily();
+        $schedule->job(new RefreshNethvoiceStatsMaterializedViews)->dailyAt('02:00')->withoutOverlapping();
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Console;
 
 use App\Jobs\RefreshNethvoiceStatsMaterializedViews;
+use App\Jobs\RefreshPhonehomeDashboardMaterializedViews;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -15,6 +16,7 @@ class Kernel extends ConsoleKernel
     {
         $schedule->command('ip-geolocation:update')->daily();
         $schedule->job(new RefreshNethvoiceStatsMaterializedViews)->dailyAt('02:00')->withoutOverlapping();
+        $schedule->job(new RefreshPhonehomeDashboardMaterializedViews)->dailyAt('02:15')->withoutOverlapping();
     }
 
     /**

--- a/app/Jobs/RefreshNethvoiceStatsMaterializedViews.php
+++ b/app/Jobs/RefreshNethvoiceStatsMaterializedViews.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
+
+class RefreshNethvoiceStatsMaterializedViews implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Materialized views to refresh, ordered so dependencies come first:
+     * nethvoice_installations must be refreshed before the aggregates that
+     * read from it.
+     *
+     * @var string[]
+     */
+    public const VIEWS = [
+        'nethvoice_installations',
+        'nethvoice_module_status',
+        'nethvoice_trunks_by_tech',
+        'nethvoice_trunks_by_provider',
+        'nethvoice_devices_by_type',
+        'nethvoice_physical_devices_by_vendor',
+        'nethvoice_physical_devices_by_model',
+        'nethvoice_proxy_installations',
+        'nethvoice_version_stats',
+        'nethvoice_country_stats',
+        'nethvoice_country_subscription_stats',
+        'nethvoice_device_type_stats',
+    ];
+
+    public function handle(): void
+    {
+        foreach (self::VIEWS as $view) {
+            DB::statement("REFRESH MATERIALIZED VIEW $view");
+        }
+    }
+}

--- a/app/Jobs/RefreshPhonehomeDashboardMaterializedViews.php
+++ b/app/Jobs/RefreshPhonehomeDashboardMaterializedViews.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
+
+class RefreshPhonehomeDashboardMaterializedViews implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Materialized views to refresh, ordered so dependencies come first:
+     * phonehome_installations must be refreshed before any aggregates that
+     * read from it.
+     *
+     * @var string[]
+     */
+    public const VIEWS = [
+        'phonehome_installations',
+        'phonehome_nethserver8_node_versions',
+        'phonehome_daily_active_counts',
+    ];
+
+    public function handle(): void
+    {
+        foreach (self::VIEWS as $view) {
+            DB::statement("REFRESH MATERIALIZED VIEW $view");
+        }
+    }
+}

--- a/containers/grafana/provisioning/dashboards/phonehome.json
+++ b/containers/grafana/provisioning/dashboards/phonehome.json
@@ -190,7 +190,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  day_series :: date AS day,\n  COUNT(id) as active_firewalls\nFROM\n  generate_series(\n    NOW() - '6 month' :: interval,\n    NOW() - '1 day' :: interval,\n    '1 day' :: interval\n  ) day_series\n  LEFT JOIN installations ON installations.created_at :: date <= day_series :: date\n  AND updated_at :: date >= day_series :: date - '7 days' :: interval\nWHERE\n  data ->> 'installation' = 'nethsecurity'\nGROUP BY\n  day;",
+          "rawSql": "SELECT\n  day,\n  active_count AS active_firewalls\nFROM\n  phonehome_daily_active_counts\nWHERE\n  category = 'nethsecurity'\nORDER BY\n  day;",
           "refId": "Nethsecurity 8 currently active",
           "sql": {
             "columns": [
@@ -219,7 +219,7 @@
           "format": "table",
           "hide": false,
           "rawQuery": true,
-          "rawSql": "SELECT\n  day_series :: date AS day,\n  COUNT(id) as active_clusters\nFROM\n  generate_series(\n    NOW() - '6 month' :: interval,\n    NOW() - '1 day' :: interval,\n    '1 day' :: interval\n  ) day_series\n  LEFT JOIN installations ON installations.created_at :: date <= day_series :: date\n  AND updated_at :: date >= day_series :: date - '7 days' :: interval\nWHERE\n  to_jsonb(data -> 'facts') ? 'nodes'\nGROUP BY\n  day;",
+          "rawSql": "SELECT\n  day,\n  active_count AS active_clusters\nFROM\n  phonehome_daily_active_counts\nWHERE\n  category = 'nethserver8'\nORDER BY\n  day;",
           "refId": "Nethserver 8 currently active",
           "sql": {
             "columns": [
@@ -248,7 +248,7 @@
           "format": "table",
           "hide": false,
           "rawQuery": true,
-          "rawSql": "SELECT\n  day_series :: date AS day,\n  COUNT(id) as installation_count\nFROM\n  generate_series(\n    NOW() - '6 month' :: interval,\n    NOW() - '1 day' :: interval,\n    '1 day' :: interval\n  ) day_series\n  LEFT JOIN installations ON installations.created_at :: date <= day_series :: date\n  AND updated_at :: date >= day_series :: date - '7 days' :: interval\nWHERE\n  NOT to_jsonb(data -> 'facts') ? 'nodes'\n  AND data ->> 'installation' = 'nethserver'\nGROUP BY\n  day;",
+          "rawSql": "SELECT\n  day,\n  active_count AS installation_count\nFROM\n  phonehome_daily_active_counts\nWHERE\n  category = 'nethserver67'\nORDER BY\n  day;",
           "refId": "NethServer 6/7 installations ",
           "sql": {
             "columns": [
@@ -334,7 +334,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT COUNT(id)\nFROM installations\nWHERE installations.updated_at > NOW() - interval '7 days';",
+          "rawSql": "SELECT COUNT(*)\nFROM phonehome_installations;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -432,7 +432,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  COUNT(installations.id) as ns_installations\nFROM\n  installations\nWHERE\n  installations.updated_at > NOW() - interval '7 days'\n  AND to_jsonb(data -> 'facts') ? 'nodes'\n  AND data ->> 'installation' = 'nethserver';",
+          "rawSql": "SELECT\n  COUNT(*) as ns_installations\nFROM\n  phonehome_installations\nWHERE\n  category = 'nethserver8';",
           "refId": "A",
           "sql": {
             "columns": [
@@ -624,7 +624,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  code,\n  name,\n  COUNT(installations.id) as old_installations\nFROM\n  installations\n  JOIN countries ON installations.country_id = countries.id\nWHERE\n  installations.updated_at > NOW() - interval '7 days'\n  AND to_jsonb(data -> 'facts') ? 'nodes'\n  AND data ->> 'installation' = 'nethserver'\nGROUP BY\n  code,\n  name;",
+          "rawSql": "SELECT\n  country_code AS code,\n  country_name AS name,\n  COUNT(*) as old_installations\nFROM\n  phonehome_installations\nWHERE\n  category = 'nethserver8'\nGROUP BY\n  country_code,\n  country_name;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -761,7 +761,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT node_count, count(id)\nFROM (SELECT id, count(nodes) as node_count\n      FROM (SELECT id, length(json_object_keys(data -> 'facts' -> 'nodes')) as nodes\n            FROM installations\n            WHERE updated_at > now() - interval '7 days') as nodes_unpack\n      GROUP BY id) as nodes_by_installation\nGROUP BY node_count\nORDER BY node_count;",
+          "rawSql": "SELECT node_count, COUNT(*)\nFROM phonehome_installations\nWHERE category = 'nethserver8'\nGROUP BY node_count\nORDER BY node_count;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -880,7 +880,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  name,\n  jsonb_path_query(to_jsonb(data), '$.facts.nodes.*') ->> 'version' as version,\n  COUNT(installations.id) as old_installations\nFROM\n  installations\n  JOIN countries ON installations.country_id = countries.id\nWHERE\n  installations.updated_at > NOW() - interval '7 days'\n  AND to_jsonb(data -> 'facts') ? 'nodes'\n  AND data ->> 'installation' = 'nethserver'\nGROUP BY\n  name,\n  version\nORDER BY old_installations DESC, version, name;",
+          "rawSql": "SELECT\n  country_name as name,\n  version,\n  COUNT(*) as old_installations\nFROM\n  phonehome_nethserver8_node_versions\nGROUP BY\n  country_name,\n  version\nORDER BY old_installations DESC, version, name;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -978,7 +978,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  COUNT(installations.id) as nsec_installations\nFROM\n  installations\nWHERE\n  installations.updated_at > NOW() - interval '7 days'\n  AND data ->> 'installation' = 'nethsecurity';",
+          "rawSql": "SELECT\n  COUNT(*) as nsec_installations\nFROM\n  phonehome_installations\nWHERE\n  category = 'nethsecurity';",
           "refId": "A",
           "sql": {
             "columns": [
@@ -1170,7 +1170,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  code,\n  name,\n  COUNT(installations.id) as nsec_installations\nFROM\n  installations\n  JOIN countries ON installations.country_id = countries.id\nWHERE\n  installations.updated_at > NOW() - interval '7 days'\n  AND data ->> 'installation' = 'nethsecurity'\nGROUP BY\n  code,\n  name;",
+          "rawSql": "SELECT\n  country_code AS code,\n  country_name AS name,\n  COUNT(*) as nsec_installations\nFROM\n  phonehome_installations\nWHERE\n  category = 'nethsecurity'\nGROUP BY\n  country_code,\n  country_name;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -1289,7 +1289,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT name, data -> 'facts' -> 'distro' ->> 'version' as version, COUNT(installations.id) as installation_count\nFROM installations\nJOIN countries ON countries.id = installations.country_id\nWHERE installations.updated_at > now() - interval '7 days'\n  AND data ->> 'installation' = 'nethsecurity'\nGROUP BY name, version\nORDER BY installation_count DESC, version, name;",
+          "rawSql": "SELECT country_name as name, version, COUNT(*) as installation_count\nFROM phonehome_installations\nWHERE category = 'nethsecurity'\nGROUP BY country_name, version\nORDER BY installation_count DESC, version, name;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -1421,7 +1421,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  name,\n  data -> 'facts' ->> 'version' as version,\n  COUNT(installations.id) as old_installations\nFROM\n  installations\n  JOIN countries ON installations.country_id = countries.id\nWHERE\n  installations.updated_at > NOW() - interval '7 days'\n  AND NOT to_jsonb(data -> 'facts') ? 'nodes'\n  AND data ->> 'installation' = 'nethserver'\nGROUP BY\n  name,\n  version\nORDER BY old_installations DESC, version, name;",
+          "rawSql": "SELECT\n  country_name as name,\n  version,\n  COUNT(*) as old_installations\nFROM\n  phonehome_installations\nWHERE\n  category = 'nethserver67'\nGROUP BY\n  country_name,\n  version\nORDER BY old_installations DESC, version, name;",
           "refId": "A",
           "sql": {
             "columns": [
@@ -1613,7 +1613,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  code,\n  name,\n  COUNT(installations.id) as old_installations\nFROM\n  installations\n  JOIN countries ON installations.country_id = countries.id\nWHERE\n  installations.updated_at > NOW() - interval '7 days'\n  AND NOT to_jsonb(data -> 'facts') ? 'nodes'\n  AND data ->> 'installation' = 'nethserver'\nGROUP BY\n  code,\n  name;",
+          "rawSql": "SELECT\n  country_code AS code,\n  country_name AS name,\n  COUNT(*) as old_installations\nFROM\n  phonehome_installations\nWHERE\n  category = 'nethserver67'\nGROUP BY\n  country_code,\n  country_name;",
           "refId": "A",
           "sql": {
             "columns": [

--- a/containers/php/entrypoint.sh
+++ b/containers/php/entrypoint.sh
@@ -23,10 +23,14 @@ elif [ "$1" = 'scheduler' ] || [ "$1" = 'worker' ]; then
         php artisan optimize
     fi
     if [ "$1" = 'scheduler' ]; then
-        set -- php artisan schedule:work --whisper
+        cmd="php artisan schedule:work --whisper"
     else
-        set -- php artisan queue:work --sleep=3 --tries=3 --max-time=3600 --timeout=0
+        cmd="php artisan queue:work --sleep=3 --tries=3 --timeout=0"
     fi
+    if [ "$(id -u)" = '0' ]; then
+        exec su -s /bin/sh www-data -c "$cmd"
+    fi
+    set -- $cmd
 fi
 
 exec "$@"

--- a/containers/php/entrypoint.sh
+++ b/containers/php/entrypoint.sh
@@ -25,7 +25,7 @@ elif [ "$1" = 'scheduler' ] || [ "$1" = 'worker' ]; then
     if [ "$1" = 'scheduler' ]; then
         set -- php artisan schedule:work --whisper
     else
-        set -- php artisan queue:work --sleep=3 --tries=3 --max-time=3600
+        set -- php artisan queue:work --sleep=3 --tries=3 --max-time=3600 --timeout=0
     fi
 fi
 

--- a/database/migrations/2026_06_30_120000_nethvoice_stats_materialized_views.php
+++ b/database/migrations/2026_06_30_120000_nethvoice_stats_materialized_views.php
@@ -1,0 +1,319 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Flattened nethvoice_* stats as materialized views so Metabase/Grafana can
+     * query them cheaply (no live JSONB unpacking). The data is refreshed nightly
+     * by RefreshNethvoiceStatsMaterializedViews (scheduled nightly via App\Console\Kernel).
+     *
+     * Raw SQL on purpose: these are JSONB-heavy materialized views the schema
+     * builder cannot express. The `nethvoice_*_stats` views read from the
+     * `nethvoice_installations` view, so it must be created first.
+     */
+    public function up(): void
+    {
+        // ========================================================
+        // nethvoice_installations
+        // One row per nethvoice module installation (last 7 days).
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW nethvoice_installations AS
+            SELECT
+                i.id                                                            AS installation_id,
+                i.country_id,
+                c.code                                                          AS country_code,
+                i.updated_at,
+                m ->> 'version'                                                 AS module_version,
+                (i.data::jsonb -> 'facts' -> 'cluster' ->> 'subscription')      AS subscription,
+
+                -- counts
+                (m ->> 'nethvoice_users_count')::int                            AS users_count,
+                (m ->> 'nethvoice_trunks_count')::int                           AS trunks_count,
+                (m ->> 'nethvoice_inbound_routes_count')::int                   AS inbound_routes_count,
+                (m ->> 'nethvoice_outbound_routes_count')::int                  AS outbound_routes_count,
+                (m ->> 'nethvoice_ivr_count')::int                              AS ivr_count,
+                (m ->> 'nethvoice_queues_count')::int                           AS queues_count,
+                (m ->> 'nethvoice_ringgroups_count')::int                       AS ringgroups_count,
+                (m ->> 'nethvoice_cqr_count')::int                              AS cqr_count,
+                (m ->> 'nethvoice_calls_last_24h')::int                         AS calls_last_24h,
+                (m ->> 'nethvoice_total_calls')::int                            AS total_calls,
+                (m ->> 'nethvoice_cti_profiles_count')::int                     AS cti_profiles_count,
+                (m ->> 'nethvoice_cti_groups_count')::int                       AS cti_groups_count,
+                (m ->> 'nethvoice_cti_users_count')::int                        AS cti_users_count,
+                (m ->> 'nethvoice_cti_2fa_enabled_count')::int                  AS cti_2fa_enabled_count,
+                (m ->> 'nethvoice_streaming_count')::int                        AS streaming_count,
+                (m ->> 'nethvoice_paramurl_count')::int                         AS paramurl_count,
+                (m ->> 'nethvoice_announcements_count')::int                    AS announcements_count,
+                (m ->> 'nethvoice_offhour_count')::int                          AS offhour_count,
+                (m ->> 'nethvoice_customer_cards_count')::int                   AS customer_cards_count,
+                (m ->> 'nethvoice_nethlink_active_count')::int                  AS nethlink_active_count,
+                (m ->> 'nethvoice_devices_count')::int                          AS devices_count,
+                (m -> 'nethvoice_devices_by_type' ->> 'mobile')::int            AS mobile_devices_count,
+                (m -> 'nethvoice_devices_by_type' ->> 'webrtc')::int            AS webrtc_devices_count,
+                (m -> 'nethvoice_devices_by_type' ->> 'physical')::int          AS physical_devices_count,
+                (m -> 'nethvoice_devices_by_type' ->> 'nethlink')::int          AS nethlink_devices_count,
+
+                -- booleans
+                (m ->> 'nethvoice_hotel_enabled')::boolean                      AS hotel_enabled,
+                (m ->> 'nethvoice_ai_call_summary_enabled')::boolean            AS ai_call_summary_enabled,
+                (m ->> 'nethvoice_ai_call_transcription_enabled')::boolean      AS ai_call_transcription_enabled,
+                (m ->> 'nethvoice_ai_voicemail_transcription_enabled')::boolean AS ai_voicemail_transcription_enabled,
+                (m ->> 'nethvoice_subscription_enabled')::boolean               AS subscription_enabled,
+
+                -- strings
+                m ->> 'nethvoice_user_domain_type'                             AS user_domain_type,
+                m ->> 'nethvoice_user_domain_location'                         AS user_domain_location
+
+            FROM installations i
+            LEFT JOIN countries c ON i.country_id = c.id,
+                LATERAL jsonb_array_elements((i.data::jsonb -> 'facts' -> 'modules')) AS m
+            WHERE m ->> 'module' = 'nethvoice'
+                AND jsonb_exists(i.data::jsonb -> 'facts', 'modules')
+                AND i.updated_at::date >= NOW()::date - INTERVAL '7 days';
+        ");
+        DB::statement('CREATE INDEX ON nethvoice_installations (installation_id)');
+        DB::statement('CREATE INDEX ON nethvoice_installations (module_version)');
+        DB::statement('CREATE INDEX ON nethvoice_installations (updated_at)');
+        DB::statement('CREATE INDEX ON nethvoice_installations (users_count)');
+        DB::statement('CREATE INDEX ON nethvoice_installations (calls_last_24h)');
+        DB::statement('CREATE INDEX ON nethvoice_installations (inbound_routes_count)');
+        DB::statement('CREATE INDEX ON nethvoice_installations (cqr_count)');
+        DB::statement('CREATE INDEX ON nethvoice_installations (country_code)');
+        DB::statement('CREATE INDEX ON nethvoice_installations (subscription)');
+
+        // ========================================================
+        // nethvoice_module_status (fast installed/not_installed queries)
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW nethvoice_module_status AS
+            SELECT
+                i.id AS installation_id,
+                EXISTS (
+                    SELECT 1 FROM jsonb_array_elements((i.data::jsonb -> 'facts' -> 'modules')) AS m
+                    WHERE m ->> 'module' = 'nethvoice'
+                ) AS has_nethvoice
+            FROM installations i
+            WHERE i.updated_at::date >= NOW()::date - INTERVAL '7 days'
+                AND jsonb_exists(i.data::jsonb -> 'facts', 'modules');
+        ");
+        DB::statement('CREATE INDEX ON nethvoice_module_status (has_nethvoice)');
+
+        // ========================================================
+        // nethvoice_trunks_by_tech
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW nethvoice_trunks_by_tech AS
+            SELECT i.id AS installation_id, kv.key AS tech, kv.value::int AS trunk_count
+            FROM installations i,
+                LATERAL jsonb_array_elements((i.data::jsonb -> 'facts' -> 'modules')) AS m,
+                LATERAL jsonb_each_text(m -> 'nethvoice_trunks_by_tech') AS kv
+            WHERE m ->> 'module' = 'nethvoice'
+                AND jsonb_exists(i.data::jsonb -> 'facts', 'modules')
+                AND i.updated_at::date >= NOW()::date - INTERVAL '7 days'
+                AND jsonb_typeof(m -> 'nethvoice_trunks_by_tech') = 'object';
+        ");
+        DB::statement('CREATE INDEX ON nethvoice_trunks_by_tech (tech)');
+
+        // ========================================================
+        // nethvoice_trunks_by_provider
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW nethvoice_trunks_by_provider AS
+            SELECT i.id AS installation_id, kv.key AS provider, kv.value::int AS trunk_count
+            FROM installations i,
+                LATERAL jsonb_array_elements((i.data::jsonb -> 'facts' -> 'modules')) AS m,
+                LATERAL jsonb_each_text(m -> 'nethvoice_trunks_by_provider') AS kv
+            WHERE m ->> 'module' = 'nethvoice'
+                AND jsonb_exists(i.data::jsonb -> 'facts', 'modules')
+                AND i.updated_at::date >= NOW()::date - INTERVAL '7 days'
+                AND jsonb_typeof(m -> 'nethvoice_trunks_by_provider') = 'object';
+        ");
+        DB::statement('CREATE INDEX ON nethvoice_trunks_by_provider (provider)');
+
+        // ========================================================
+        // nethvoice_devices_by_type
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW nethvoice_devices_by_type AS
+            SELECT i.id AS installation_id, kv.key AS device_type, kv.value::int AS device_count
+            FROM installations i,
+                LATERAL jsonb_array_elements((i.data::jsonb -> 'facts' -> 'modules')) AS m,
+                LATERAL jsonb_each_text(m -> 'nethvoice_devices_by_type') AS kv
+            WHERE m ->> 'module' = 'nethvoice'
+                AND jsonb_exists(i.data::jsonb -> 'facts', 'modules')
+                AND i.updated_at::date >= NOW()::date - INTERVAL '7 days'
+                AND jsonb_typeof(m -> 'nethvoice_devices_by_type') = 'object';
+        ");
+        DB::statement('CREATE INDEX ON nethvoice_devices_by_type (device_type)');
+
+        // ========================================================
+        // nethvoice_physical_devices_by_vendor
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW nethvoice_physical_devices_by_vendor AS
+            SELECT i.id AS installation_id, kv.key AS vendor, kv.value::int AS device_count
+            FROM installations i,
+                LATERAL jsonb_array_elements((i.data::jsonb -> 'facts' -> 'modules')) AS m,
+                LATERAL jsonb_each_text(m -> 'nethvoice_physical_devices_by_vendor') AS kv
+            WHERE m ->> 'module' = 'nethvoice'
+                AND jsonb_exists(i.data::jsonb -> 'facts', 'modules')
+                AND i.updated_at::date >= NOW()::date - INTERVAL '7 days'
+                AND jsonb_typeof(m -> 'nethvoice_physical_devices_by_vendor') = 'object';
+        ");
+        DB::statement('CREATE INDEX ON nethvoice_physical_devices_by_vendor (vendor)');
+
+        // ========================================================
+        // nethvoice_physical_devices_by_model
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW nethvoice_physical_devices_by_model AS
+            SELECT i.id AS installation_id, kv.key AS model, kv.value::int AS device_count
+            FROM installations i,
+                LATERAL jsonb_array_elements((i.data::jsonb -> 'facts' -> 'modules')) AS m,
+                LATERAL jsonb_each_text(m -> 'nethvoice_physical_devices_by_model') AS kv
+            WHERE m ->> 'module' = 'nethvoice'
+                AND jsonb_exists(i.data::jsonb -> 'facts', 'modules')
+                AND i.updated_at::date >= NOW()::date - INTERVAL '7 days'
+                AND jsonb_typeof(m -> 'nethvoice_physical_devices_by_model') = 'object';
+        ");
+        DB::statement('CREATE INDEX ON nethvoice_physical_devices_by_model (model)');
+
+        // ========================================================
+        // nethvoice_proxy_installations
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW nethvoice_proxy_installations AS
+            SELECT
+                i.id AS installation_id,
+                i.country_id,
+                c.code AS country_code,
+                i.updated_at,
+                m ->> 'version' AS module_version
+            FROM installations i
+            LEFT JOIN countries c ON i.country_id = c.id,
+                LATERAL jsonb_array_elements((i.data::jsonb -> 'facts' -> 'modules')) AS m
+            WHERE m ->> 'module' = 'nethvoice-proxy'
+                AND jsonb_exists(i.data::jsonb -> 'facts', 'modules')
+                AND i.updated_at::date >= NOW()::date - INTERVAL '7 days';
+        ");
+        DB::statement('CREATE INDEX ON nethvoice_proxy_installations (module_version)');
+        DB::statement('CREATE INDEX ON nethvoice_proxy_installations (updated_at)');
+        DB::statement('CREATE INDEX ON nethvoice_proxy_installations (country_code)');
+
+        // ========================================================
+        // nethvoice_version_stats (pre-aggregated version counts)
+        // ========================================================
+        DB::statement('
+            CREATE MATERIALIZED VIEW nethvoice_version_stats AS
+            SELECT
+                module_version,
+                COUNT(*) AS installation_count
+            FROM nethvoice_installations
+            GROUP BY module_version
+            ORDER BY installation_count DESC;
+        ');
+        DB::statement('CREATE INDEX ON nethvoice_version_stats (module_version)');
+
+        // ========================================================
+        // nethvoice_country_stats (pre-aggregated by country)
+        // ========================================================
+        DB::statement('
+            CREATE MATERIALIZED VIEW nethvoice_country_stats AS
+            SELECT
+                country_code,
+                COUNT(DISTINCT installation_id) AS installation_count
+            FROM nethvoice_installations
+            WHERE country_code IS NOT NULL
+            GROUP BY country_code
+            ORDER BY installation_count DESC;
+        ');
+        DB::statement('CREATE INDEX ON nethvoice_country_stats (country_code)');
+
+        // ========================================================
+        // nethvoice_country_subscription_stats (by country & subscription)
+        // ========================================================
+        DB::statement('
+            CREATE MATERIALIZED VIEW nethvoice_country_subscription_stats AS
+            SELECT
+                country_code,
+                subscription,
+                COUNT(DISTINCT installation_id) AS installation_count
+            FROM nethvoice_installations
+            WHERE country_code IS NOT NULL AND subscription IS NOT NULL
+            GROUP BY country_code, subscription
+            ORDER BY installation_count DESC;
+        ');
+        DB::statement('CREATE INDEX ON nethvoice_country_subscription_stats (country_code, subscription)');
+
+        // ========================================================
+        // nethvoice_device_type_stats (pre-aggregated device stats)
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW nethvoice_device_type_stats AS
+            SELECT
+                'average_users'::text AS metric,
+                ROUND(AVG(users_count)::numeric, 2) AS value
+            FROM nethvoice_installations
+            WHERE users_count IS NOT NULL
+            UNION ALL
+            SELECT 'max_users', MAX(users_count)::numeric FROM nethvoice_installations
+            UNION ALL
+            SELECT 'average_mobile_devices', ROUND(AVG(mobile_devices_count)::numeric, 2) FROM nethvoice_installations WHERE mobile_devices_count IS NOT NULL
+            UNION ALL
+            SELECT 'max_mobile_devices', MAX(mobile_devices_count)::numeric FROM nethvoice_installations
+            UNION ALL
+            SELECT 'average_webrtc_devices', ROUND(AVG(webrtc_devices_count)::numeric, 2) FROM nethvoice_installations WHERE webrtc_devices_count IS NOT NULL
+            UNION ALL
+            SELECT 'max_webrtc_devices', MAX(webrtc_devices_count)::numeric FROM nethvoice_installations
+            UNION ALL
+            SELECT 'average_physical_devices', ROUND(AVG(physical_devices_count)::numeric, 2) FROM nethvoice_installations WHERE physical_devices_count IS NOT NULL
+            UNION ALL
+            SELECT 'max_physical_devices', MAX(physical_devices_count)::numeric FROM nethvoice_installations
+            UNION ALL
+            SELECT 'average_nethlink_devices', ROUND(AVG(nethlink_devices_count)::numeric, 2) FROM nethvoice_installations WHERE nethlink_devices_count IS NOT NULL
+            UNION ALL
+            SELECT 'max_nethlink_devices', MAX(nethlink_devices_count)::numeric FROM nethvoice_installations;
+        ");
+
+        // ========================================================
+        // Grant read access to the Metabase user
+        // ========================================================
+        $metabaseUser = config('metabase.username');
+        foreach (self::VIEWS as $view) {
+            DB::statement("GRANT SELECT ON $view TO $metabaseUser;");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // CASCADE drops the aggregate views that read from nethvoice_installations.
+        foreach (array_reverse(self::VIEWS) as $view) {
+            DB::statement("DROP MATERIALIZED VIEW IF EXISTS $view CASCADE");
+        }
+    }
+
+    /**
+     * All materialized views, ordered so dependencies come before dependents.
+     */
+    private const VIEWS = [
+        'nethvoice_installations',
+        'nethvoice_module_status',
+        'nethvoice_trunks_by_tech',
+        'nethvoice_trunks_by_provider',
+        'nethvoice_devices_by_type',
+        'nethvoice_physical_devices_by_vendor',
+        'nethvoice_physical_devices_by_model',
+        'nethvoice_proxy_installations',
+        'nethvoice_version_stats',
+        'nethvoice_country_stats',
+        'nethvoice_country_subscription_stats',
+        'nethvoice_device_type_stats',
+    ];
+};

--- a/database/migrations/2026_07_01_120000_phonehome_dashboard_materialized_views.php
+++ b/database/migrations/2026_07_01_120000_phonehome_dashboard_materialized_views.php
@@ -1,0 +1,164 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Flattened phonehome dashboard stats as materialized views so the
+     * Grafana "PhoneHome" dashboard (containers/grafana/provisioning/dashboards/phonehome.json)
+     * can query them cheaply (no live JSONB unpacking / generate_series over
+     * the full installations table on every dashboard load). Refreshed
+     * nightly by RefreshPhonehomeDashboardMaterializedViews.
+     *
+     * Raw SQL on purpose: these are JSONB-heavy materialized views the schema
+     * builder cannot express. `phonehome_daily_active_counts` reads directly
+     * from `installations` (not from `phonehome_installations`, which only
+     * covers the last 7 days) because historical days need installations
+     * that are no longer "currently active".
+     */
+    public function up(): void
+    {
+        // ========================================================
+        // phonehome_installations
+        // One row per currently active (last 7 days) installation,
+        // classified into nethsecurity / nethserver8 / nethserver67.
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW phonehome_installations AS
+            SELECT
+                t.installation_id,
+                t.country_id,
+                t.country_code,
+                t.country_name,
+                t.category,
+                CASE
+                    WHEN t.category = 'nethsecurity' THEN t.data -> 'facts' -> 'distro' ->> 'version'
+                    WHEN t.category = 'nethserver67' THEN t.data -> 'facts' ->> 'version'
+                END AS version,
+                CASE
+                    WHEN t.category = 'nethserver8' THEN (SELECT COUNT(*) FROM jsonb_object_keys(t.data -> 'facts' -> 'nodes'))
+                END AS node_count,
+                t.updated_at
+            FROM (
+                SELECT
+                    i.id AS installation_id,
+                    i.country_id,
+                    c.code AS country_code,
+                    c.name AS country_name,
+                    i.updated_at,
+                    i.data::jsonb AS data,
+                    CASE
+                        WHEN i.data::jsonb ->> 'installation' = 'nethsecurity' THEN 'nethsecurity'
+                        WHEN i.data::jsonb ->> 'installation' = 'nethserver'
+                            AND jsonb_exists(i.data::jsonb -> 'facts', 'nodes') THEN 'nethserver8'
+                        ELSE 'nethserver67'
+                    END AS category
+                FROM installations i
+                LEFT JOIN countries c ON i.country_id = c.id
+                WHERE i.updated_at > NOW() - INTERVAL '7 days'
+                    AND i.data::jsonb ->> 'installation' IN ('nethsecurity', 'nethserver')
+            ) t;
+        ");
+        DB::statement('CREATE UNIQUE INDEX ON phonehome_installations (installation_id)');
+        DB::statement('CREATE INDEX ON phonehome_installations (category)');
+        DB::statement('CREATE INDEX ON phonehome_installations (country_code)');
+
+        // ========================================================
+        // phonehome_nethserver8_node_versions
+        // One row per node, for active nethserver8 clusters.
+        // ========================================================
+        DB::statement("
+            CREATE MATERIALIZED VIEW phonehome_nethserver8_node_versions AS
+            SELECT
+                i.id AS installation_id,
+                c.code AS country_code,
+                c.name AS country_name,
+                kv.key AS node_key,
+                kv.value ->> 'version' AS version
+            FROM installations i
+            LEFT JOIN countries c ON i.country_id = c.id,
+                LATERAL jsonb_each(i.data::jsonb -> 'facts' -> 'nodes') AS kv
+            WHERE i.data::jsonb ->> 'installation' = 'nethserver'
+                AND jsonb_exists(i.data::jsonb -> 'facts', 'nodes')
+                AND i.updated_at > NOW() - INTERVAL '7 days';
+        ");
+        DB::statement('CREATE UNIQUE INDEX ON phonehome_nethserver8_node_versions (installation_id, node_key)');
+        DB::statement('CREATE INDEX ON phonehome_nethserver8_node_versions (country_name)');
+
+        // ========================================================
+        // phonehome_daily_active_counts
+        // Per-day, per-category active install count over the last 6
+        // months (the "Active Installations" timeseries panel). Reads
+        // the raw installations table since old rows outside the
+        // current 7-day window still count as active on past days.
+        // ========================================================
+        // Category/date bounds computed once per row (CTE) instead of once
+        // per (day x category) join comparison — the naive CROSS JOIN version
+        // re-evaluates the JSONB extraction ~3000x per row and took 15+
+        // minutes against 143k installations; this version takes seconds.
+        DB::statement("
+            CREATE MATERIALIZED VIEW phonehome_daily_active_counts AS
+            WITH categorized AS (
+                SELECT
+                    i.created_at::date AS created_date,
+                    i.updated_at::date AS updated_date,
+                    CASE
+                        WHEN i.data::jsonb ->> 'installation' = 'nethsecurity' THEN 'nethsecurity'
+                        WHEN i.data::jsonb ->> 'installation' = 'nethserver'
+                            AND jsonb_exists(i.data::jsonb -> 'facts', 'nodes') THEN 'nethserver8'
+                        ELSE 'nethserver67'
+                    END AS category
+                FROM installations i
+                WHERE i.data::jsonb ->> 'installation' IN ('nethsecurity', 'nethserver')
+            )
+            SELECT
+                d.day::date AS day,
+                cat.category,
+                COUNT(c.category) AS active_count
+            FROM generate_series(
+                    NOW() - '6 months'::interval,
+                    NOW() - '1 day'::interval,
+                    '1 day'::interval
+                 ) AS d(day)
+            CROSS JOIN (VALUES ('nethsecurity'), ('nethserver8'), ('nethserver67')) AS cat(category)
+            LEFT JOIN categorized c
+                ON c.category = cat.category
+                AND c.created_date <= d.day::date
+                AND c.updated_date >= d.day::date - '7 days'::interval
+            GROUP BY d.day, cat.category
+            ORDER BY d.day, cat.category;
+        ");
+        DB::statement('CREATE UNIQUE INDEX ON phonehome_daily_active_counts (day, category)');
+
+        // ========================================================
+        // Grant read access to the Grafana user (the PhoneHome
+        // dashboard is served over the Grafana postgres datasource).
+        // ========================================================
+        $grafanaUser = config('grafana.database_username');
+        foreach (self::VIEWS as $view) {
+            DB::statement("GRANT SELECT ON $view TO $grafanaUser;");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // CASCADE drops the aggregate views that read from phonehome_installations.
+        foreach (array_reverse(self::VIEWS) as $view) {
+            DB::statement("DROP MATERIALIZED VIEW IF EXISTS $view CASCADE");
+        }
+    }
+
+    /**
+     * All materialized views, ordered so dependencies come before dependents.
+     */
+    private const VIEWS = [
+        'phonehome_installations',
+        'phonehome_nethserver8_node_versions',
+        'phonehome_daily_active_counts',
+    ];
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,6 @@ services:
         environment:
             FPM_URL: app
             FPM_PORT: 9000
-
     adminer:
         image: adminer:5.4.2
         ports:

--- a/tests/Feature/PhonehomeDashboardMaterializedViewsTest.php
+++ b/tests/Feature/PhonehomeDashboardMaterializedViewsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Jobs\RefreshPhonehomeDashboardMaterializedViews;
+use App\Models\Installation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class)->group('phonehome-dashboard');
+
+it('flattens active installations into phonehome_installations, classified by category', function () {
+    $nethsecurity = Installation::factory()->nethsecurity()->create();
+    $nethserver8 = Installation::factory()->nethserver()->create();
+    $legacy = Installation::factory()->create();
+
+    RefreshPhonehomeDashboardMaterializedViews::dispatchSync();
+
+    $rows = DB::table('phonehome_installations')->get()->keyBy('installation_id');
+
+    expect($rows[$nethsecurity->id]->category)->toBe('nethsecurity')
+        ->and($rows[$nethsecurity->id]->version)->toBe($nethsecurity->data['facts']['distro']['version'])
+        ->and($rows[$nethsecurity->id]->node_count)->toBeNull();
+
+    expect($rows[$nethserver8->id]->category)->toBe('nethserver8')
+        ->and((int) $rows[$nethserver8->id]->node_count)->toBe(1)
+        ->and($rows[$nethserver8->id]->version)->toBeNull();
+
+    expect($rows[$legacy->id]->category)->toBe('nethserver67')
+        ->and($rows[$legacy->id]->version)->toBe($legacy->data['facts']['version']);
+});
+
+it('unnests nethserver8 nodes into phonehome_nethserver8_node_versions', function () {
+    $installation = Installation::factory()->nethserver()->create();
+
+    RefreshPhonehomeDashboardMaterializedViews::dispatchSync();
+
+    $rows = DB::table('phonehome_nethserver8_node_versions')
+        ->where('installation_id', $installation->id)
+        ->get();
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows->first()->node_key)->toBe('1')
+        ->and($rows->first()->version)->toBe($installation->data['facts']['nodes']['1']['version']);
+});
+
+it('refreshes phonehome_daily_active_counts with historical per-day activity', function () {
+    $yesterday = now()->subDay();
+
+    Installation::factory()->nethsecurity()->create([
+        'created_at' => $yesterday->copy()->subDays(2),
+        'updated_at' => $yesterday,
+    ]);
+
+    RefreshPhonehomeDashboardMaterializedViews::dispatchSync();
+
+    $row = DB::table('phonehome_daily_active_counts')
+        ->where('day', $yesterday->toDateString())
+        ->where('category', 'nethsecurity')
+        ->first();
+
+    expect($row)->not->toBeNull()
+        ->and((int) $row->active_count)->toBeGreaterThanOrEqual(1);
+});


### PR DESCRIPTION
## What

Adds nightly-refreshed `nethvoice_*` and `phonehome_*` **materialized views** so Metabase/Grafana can query pre-flattened stats without live JSONB unpacking.

## Key files

- `database/migrations/2026_06_30_120000_nethvoice_stats_materialized_views.php` — creates 12 materialized views via `DB::statement()`
- `app/Jobs/RefreshNethvoiceStatsMaterializedViews.php` — refreshes views in dependency order
- `app/Console/Kernel.php` — schedules job nightly at 02:00 with `withoutOverlapping()`
- `app/Console/Commands/NethvoiceRefreshStatsCommand.php` — `php artisan nethvoice:refresh-stats` for manual runs

## PhoneHome dashboard views

Same pattern applied to the PhoneHome Grafana dashboard:

- `phonehome_installations`, `phonehome_nethserver8_node_versions`, `phonehome_daily_active_counts` — replace the JSONB-unpacking queries in `phonehome.json` with plain `SELECT`s.
- Nightly refresh: `RefreshPhonehomeDashboardMaterializedViews` job, `phonehome:refresh-dashboard-stats` command, scheduled `dailyAt('02:15')`.
- Dashboard panels rewired to the new views (`containers/grafana/provisioning/dashboards/phonehome.json`).
- Grants `SELECT` to the Grafana DB user.

